### PR TITLE
Update replica_mode config to null if not enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ locals {
   ip_cidr_range = var.use_private_g_services ? null : var.ip_cidr_range
 
   # Read-replica settings
-  replica_mode  = var.read_replicas_enabled ? "READ_REPLICAS_ENABLED" : "READ_REPLICAS_DISABLED"
+  replica_mode  = var.read_replicas_enabled ? "READ_REPLICAS_ENABLED" : null
   replica_count = var.read_replicas_enabled ? var.read_replicas_count : null
 
   # secondary_ip_range is required when *changing* from "READ_REPLICAS_DISABLED" to "READ_REPLICAS_ENABLED"


### PR DESCRIPTION
**To fix error: Read replicas mode cannot be edited on a basic tier instance.**

```
com.google.apps.framework.request.StatusException: <eye3 title='INVALID_ARGUMENT'/> generic::INVALID_ARGUMENT: Read replicas mode cannot be edited on a basic tier instance.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.BadRequest",
    "fieldViolations": [
      {
        "description": "Invalid value: READ_REPLICAS_DISABLED",
        "field": "instance.read_replicas_mode"
      }
    ]
  }
]
```

According to [terraform doc of google_redis_instance for variable read_replicas_mode](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance#read_replicas_mode),  "If not set, Memorystore Redis backend will default to READ_REPLICAS_DISABLED."

Therefore, the variable can be set to `null`, if no replica is required. It will result in the default value of `READ_REPLICAS_DISABLED` internally.